### PR TITLE
Minor fixes to match release announcement

### DIFF
--- a/DynamicTest.cc
+++ b/DynamicTest.cc
@@ -38,18 +38,17 @@ TEST(Dynamic, Initialization) {
 }
 
 TEST(Dynamic, ContainerInit) {
-  dynamic d1 = std::vector<int64_t>({ 1L, 2L, 3L });
+  dynamic d1{std::vector<int64_t>{ 1L, 2L, 3L }};
   EXPECT_TRUE(d1.is_of<std::vector<int64_t>>());
   auto& v1 = d1.getRef<std::vector<int64_t>>();
   EXPECT_EQ(3, v1.size());
 
-  dynamic d2 = std::vector<folly::StringPiece>(
-    {"foo", "bar", "baz" });
+  dynamic d2{std::vector<folly::StringPiece>{"foo", "bar", "baz" }};
   EXPECT_TRUE(d2.is_of<std::vector<folly::StringPiece>>());
   auto& v2 = d2.getRef<std::vector<folly::StringPiece>>();
   EXPECT_EQ(3, v2.size());
 
-  dynamic d3 = std::vector<dynamic>({ 1L, "foo", 3L });
+  dynamic d3{std::vector<dynamic>{ 1L, "foo", 3L }};
   EXPECT_TRUE(d3.is_of<vector_dynamic_t>());
   auto& v3 = d3.getRef<vector_dynamic_t>();
   EXPECT_EQ(3, v3.size());

--- a/DynamicTest.cc
+++ b/DynamicTest.cc
@@ -8,8 +8,9 @@
 #include <folly/Benchmark.h>
 #include <folly/io/async/EventBaseManager.h>
 
-#include "iterlib/variant/dynamic.h"
+#include "iterlib/dynamic.h"
 
+using namespace iterlib;
 using namespace iterlib::variant;
 
 TEST(Dynamic, DefaultValues) {

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ conversion to native types) are used here.
 TODO:
 ====
 
+* Implement zero-copy iterators on top of the dynamic
+
 * Faster conversion to json. Right now, requires conversion to folly::dynamic
   and then to json
 

--- a/iterlib/dynamic.h
+++ b/iterlib/dynamic.h
@@ -1,0 +1,12 @@
+//  Copyright (c) 2016, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include "iterlib/variant/dynamic.h"
+
+namespace iterlib {
+typedef iterlib::variant::dynamic dynamic;
+}


### PR DESCRIPTION
* We talked about iterlib::dynamic, but no such thing in the code.
* We talked about zero copy iterators that are not there yet
* Encourage brace initializers in the test (more instances to be fixed)