### PR TITLE
Some benchmarks to compare against folly::dynamic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ foreach(sourcefile ${BINS})
     target_link_libraries(${exename}${ARTIFACT_SUFFIX} dynamic-shared
                           gtest glog rt double-conversion
                           ${FOLLY_LIBRARIES}
+                          ${FOLLY_BENCHMARK_LIBRARIES}
                           ${Boost_LIBRARIES}
                           ${CMAKE_THREAD_LIBS_INIT})
     set_property(TARGET ${exename}${ARTIFACT_SUFFIX} PROPERTY CXX_STANDARD 14)

--- a/cmake/modules/FindFolly.cmake
+++ b/cmake/modules/FindFolly.cmake
@@ -27,6 +27,11 @@ find_library(FOLLY_LIBRARIES
     HINTS ${FOLLY_ROOT_DIR}/lib
 )
 
+find_library(FOLLY_BENCHMARK_LIBRARIES
+    NAMES follybenchmark
+    HINTS ${FOLLY_ROOT_DIR}/lib
+)
+
 find_path(FOLLY_INCLUDE_DIR
     NAMES folly/folly-config.h
     HINTS ${FOLLY_ROOT_DIR}/include
@@ -41,5 +46,6 @@ find_package_handle_standard_args(Folly DEFAULT_MSG
 mark_as_advanced(
     FOLLY_ROOT_DIR
     FOLLY_LIBRARIES
+    FOLLY_BENCHMARK_LIBRARIES
     FOLLY_INCLUDE_DIR
 )


### PR DESCRIPTION
The benchmarks are really comparing ordered_map_t vs vector_pair_t, not really the effect of zero copy. 

```
============================================================================
/home/arun/src/iterlib/tests/DynamicTest.cc     relative  time/iter  iters/s
============================================================================
FollyDynamicToString(100000)                                19.56ms    51.13
DynamicToString(100000)                                     15.68ms    63.79
============================================================================

	Maximum resident set size (kbytes): 57836 (folly)
	Maximum resident set size (kbytes): 31516 (iterlib)

```