### PR TITLE
OrderBy Iterator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SOURCES
   src/ReverseIterator.cpp
   src/RandomIterator.cpp
   src/CountIterator.cpp
+  src/OrderByIterator.cpp
   src/Item.cpp
 )
 
@@ -70,6 +71,7 @@ set(TESTS
         tests/DynamicTest.cpp
         tests/IteratorTest.cpp
         tests/RocksDBIteratorTest.cpp
+        tests/OrderByIteratorTest.cpp
 )
 
 set(BINS ${APPS} ${TESTS})

--- a/include/iterlib/OrderByIterator.h
+++ b/include/iterlib/OrderByIterator.h
@@ -1,0 +1,94 @@
+// Copyright 2015 - present, Facebook
+
+#pragma once
+
+#include "iterlib/WrappedIterator.h"
+
+namespace iterlib {
+
+class OrderByIterator : public WrappedIterator {
+ public:
+  OrderByIterator(Iterator* iter, AttributeNameVec orderByColumns,
+                  std::vector<bool> isColumnDescending)
+      : WrappedIterator(iter), orderByColumns_(std::move(orderByColumns)),
+        isColumnDescending_(std::move(isColumnDescending)), first_(true) {
+    CHECK_EQ(orderByColumns_.size(), isColumnDescending_.size());
+    if ((innerIter_ == nullptr) || (innerIter_->done())) {
+      prepared_ = true;
+      setDone();
+      return;
+    }
+  }
+
+  OrderByIterator(Iterator* iter, AttributeNameVec orderByColumns)
+      : OrderByIterator(iter, orderByColumns,
+                        std::vector<bool>(orderByColumns.size(), true)) {}
+
+  virtual ~OrderByIterator() {}
+
+  struct Comparator {
+    Comparator(const AttributeNameVec& columns,
+               const std::vector<bool>& isColumnDescending)
+        : columns_(columns), isColumnDescending_(isColumnDescending) {}
+
+    // columns_ and isColumnDescending are of the same size, and
+    // isColumnDescending_[i] indicates if columns_[i] is in descending order
+    const AttributeNameVec& columns_;
+    const std::vector<bool>& isColumnDescending_;
+    bool operator()(const std::pair<const Item*, int>& v1,
+                    const std::pair<const Item*, int>& v2) const;
+  };
+
+  virtual const Item& value() const override {
+    if (!results_.empty()) {
+      return *results_.front().first;
+    } else {
+      return Item::kEmptyItem;
+    }
+  }
+
+  bool doNext() override {
+    if (done()) {
+      return false;
+    }
+
+    if (first_) {
+      load();
+      first_ = false;
+    } else {
+      std::pop_heap(results_.begin(), results_.end(),
+                    Comparator(orderByColumns_, isColumnDescending_));
+      results_.pop_back();
+    }
+
+    if (results_.empty()) {
+      setDone();
+      return false;
+    }
+
+    return true;
+  }
+
+  const AttributeNameVec& orderByColumns() const { return orderByColumns_; }
+
+  const std::vector<bool>& isDescending() const { return isColumnDescending_; }
+
+ protected:
+  void load() {
+    int sequenceNum = 0;
+    while (innerIter_->next()) {
+      results_.push_back(std::make_pair(&(innerIter_->value()), sequenceNum));
+      ++sequenceNum;
+    }
+
+    std::make_heap(results_.begin(), results_.end(),
+                   Comparator(orderByColumns_, isColumnDescending_));
+  }
+
+ private:
+  std::vector<std::pair<const Item*, int>> results_;
+  AttributeNameVec orderByColumns_;
+  std::vector<bool> isColumnDescending_;
+  bool first_;
+};
+}

--- a/src/OrderByIterator.cpp
+++ b/src/OrderByIterator.cpp
@@ -1,0 +1,15 @@
+// Copyright 2015 - present, Facebook
+
+#include "iterlib/OrderByIterator.h"
+
+namespace iterlib {
+
+bool OrderByIterator::Comparator::
+operator()(const std::pair<const Item*, int>& v1,
+           const std::pair<const Item*, int>& v2) const {
+  auto cmp =
+      partialCompare(*v1.first, *v2.first, columns_, isColumnDescending_);
+  return cmp == PartialOrder::LT ||
+         (cmp == PartialOrder::EQ && v1.second > v2.second);
+}
+}

--- a/tests/OrderByIteratorTest.cpp
+++ b/tests/OrderByIteratorTest.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+
+#include "ExpectIterator.h"
+
+#include "iterlib/FutureIterator.h"
+#include "iterlib/OrderByIterator.h"
+
+using namespace folly;
+using namespace iterlib::variant;
+using namespace iterlib;
+
+TEST(OrderByIterator, OrderByOneAttr) {
+  const auto res = std::vector<ItemOptimized>{{
+      {1, 0, ordered_map_t{{"int1", 1L}, {"int2", 2L}}},
+      {2, 0, ordered_map_t{{"int1", 1L}, {"int2", 3L}}},
+      {3, 0, ordered_map_t{{"int1", 2L}, {"int2", 4L}}},
+      {3, 0, ordered_map_t{{"int1", 2L}, {"int2", 3L}}},
+  }};
+  const auto orderedResult =
+      std::vector<ItemOptimized>{{res[2], res[3], res[0], res[1]}};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto orderByIt = folly::make_unique<OrderByIterator>(
+      it.release(), AttributeNameVec{{"int1"}});
+
+  ExpectIterator(orderByIt.get(), orderedResult);
+}
+
+TEST(OrderByIterator, OrderByTwoAttr) {
+  const auto res = std::vector<ItemOptimized>{{
+      {1, 0, ordered_map_t{{"int1", 1L},
+                           {"int2", 1L},
+                           {"string", std::string{"foo"}}}},
+      {2, 0, ordered_map_t{{"int1", 1L},
+                           {"int2", 1L},
+                           {"string", std::string{"bar"}}}},
+      {2, 0, ordered_map_t{{"int1", 1L},
+                           {"int2", 2L},
+                           {"string", std::string{"foo"}}}},
+      {2, 0, ordered_map_t{{"int1", 2L},
+                           {"int2", 2L},
+                           {"string", std::string{"baz"}}}},
+  }};
+  const auto orderedResult =
+      std::vector<ItemOptimized>{{res[3], res[2], res[0], res[1]}};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto orderByIt = folly::make_unique<OrderByIterator>(
+      it.release(), AttributeNameVec{{{"int1"}, {"int2"}}});
+
+  ExpectIterator(orderByIt.get(), orderedResult);
+}
+
+TEST(OrderByIterator, OrderByTwoAttrMixed) {
+  const auto res = std::vector<ItemOptimized>{{
+      {1, 0, ordered_map_t{{"int1", 1L},
+                           {"int2", 1L},
+                           {"string", std::string{"foo"}}}},
+      {2, 0, ordered_map_t{{"int1", 1L},
+                           {"int2", 1L},
+                           {"string", std::string{"bar"}}}},
+      {2, 0, ordered_map_t{{"int1", 1L},
+                           {"int2", 2L},
+                           {"string", std::string{"foo"}}}},
+      {2, 0, ordered_map_t{{"int1", 2L},
+                           {"int2", 2L},
+                           {"string", std::string{"baz"}}}},
+  }};
+  const auto orderedResult =
+      std::vector<ItemOptimized>{{res[2], res[0], res[1], res[3]}};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto orderByIt = folly::make_unique<OrderByIterator>(
+      it.release(), AttributeNameVec{{{"int1"}, {"int2"}}},
+      // int1 ascending, int2 descending
+      std::vector<bool>{{false, true}});
+
+  ExpectIterator(orderByIt.get(), orderedResult);
+}
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION

Performs **inplace** reordering of the `Item`s in the inner iterator using pointers.
Supports ordering all combinations of ascending and descending orders.

Since the lexicographic order is special and common, `orderByColumns_.size() == 0` means lexicographic order.