### PR TITLE
Filter Iterator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(SOURCES
   src/MergeIterator.cpp
   src/ProjectIterator.cpp
   src/GroupByIterator.cpp
+  src/FilterIterator.cpp
   src/Item.cpp
 )
 
@@ -83,6 +84,7 @@ set(TESTS
         tests/ProjectIteratorTest.cpp
         tests/LetIteratorTest.cpp
         tests/GroupByIteratorTest.cpp
+        tests/FilterIteratorTest.cpp
 )
 
 set(BINS ${APPS} ${TESTS})

--- a/include/iterlib/FilterIterator.h
+++ b/include/iterlib/FilterIterator.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "iterlib/WrappedIterator.h"
+
+namespace iterlib {
+
+enum class FilterType {
+  INVALID = 0,
+  GE,
+  GT,
+  LE,
+  LT,
+  EQ,
+  NE,
+  EXISTS,
+  PREFIX,
+  CONTAINS,
+  // These types can take more than one argument
+  RANGE,
+  INSET,
+};
+
+class FilterIteratorBase : public WrappedIterator {
+ public:
+  explicit FilterIteratorBase(Iterator* iter) : WrappedIterator(iter) {}
+
+  bool orderPreserving() const override { return true; }
+
+ protected:
+  bool doNext() override;
+
+  bool doSkipTo(id_t id) override;
+
+  virtual bool match(const Iterator* iter) = 0;
+};
+
+class FilterIterator : public FilterIteratorBase {
+ public:
+  explicit FilterIterator(Iterator* iter)
+      : FilterIteratorBase(iter), firstTime_(true) {}
+
+  void setFilter(const std::vector<std::string>& fields,
+                 const std::vector<dynamic>& values, FilterType filterType) {
+    if (fields.size() == 1) {
+      fields_ = fields[0];
+    } else {
+      auto fieldVec = variant::vector_dynamic_t();
+      for (const auto& v : fields) {
+        fieldVec.emplace_back(v);
+      }
+      fields_ = std::move(fieldVec);
+    }
+
+    // We support FilterType operators with:
+    //  1 field, 1 value
+    //  1 field, n values
+    // and some combination of the two
+    //
+    // TODO: Better detection of incorrect arity of field/values
+    // Eg: (filter (= (a  b) (1 2 3)))
+    auto valueVec = variant::vector_dynamic_t();
+    int i = 0;
+    for (const auto& value : values) {
+      // Use other type information for attributes
+      // that are ints
+      if ((i < fields.size()) &&
+          (fields[i] == kIdKey || (fields[i] == kTimeKey))) {
+        int64_t intVal;
+        if (value.is_of<int64_t>()) {
+          intVal = value.get<int64_t>();
+        } else {
+          intVal = folly::to<int64_t>(value.toString());
+        }
+        valueVec.emplace_back(intVal);
+      } else {
+        valueVec.push_back(value);
+      }
+      i++;
+    }
+    values_ = std::move(valueVec);
+    filterType_ = filterType;
+  }
+
+ protected:
+  virtual bool match(const Iterator* iter) override;
+
+ private:
+  // filter information
+  dynamic fields_;
+  dynamic values_;
+
+  bool firstTime_;
+
+  FilterType filterType_;
+};
+}

--- a/src/FilterIterator.cpp
+++ b/src/FilterIterator.cpp
@@ -1,0 +1,116 @@
+#include "iterlib/FilterIterator.h"
+
+namespace iterlib {
+
+using variant::vector_dynamic_t;
+
+bool FilterIteratorBase::doNext() {
+  while (innerIter_->next()) {
+    try {
+      if (match(innerIter_.get())) {
+        return true;
+      }
+    } catch (const std::exception& ex) {
+      LOG_EVERY_N(WARNING, 1000) << "match failed on :id : " << innerIter_->id()
+                                 << " " << ex.what();
+    }
+  }
+  setDone();
+  return false;
+}
+
+bool FilterIteratorBase::doSkipTo(id_t id) {
+  if (!innerIter_->skipTo(id)) {
+    setDone();
+    return false;
+  }
+  if (match(innerIter_.get())) {
+    return true;
+  }
+
+  while (innerIter_->next()) {
+    if (match(innerIter_.get())) {
+      return true;
+    }
+  }
+
+  setDone();
+  return false;
+}
+
+bool FilterIterator::match(const Iterator* iter) {
+  dynamic v;
+  auto& values = reinterpret_cast<std::vector<dynamic>&>(
+      values_.getNonConstRef<vector_dynamic_t>());
+  if (fields_.is_of<std::string>()) {
+    if (fields_ == dynamic(kIdKey)) {
+      v = static_cast<int64_t>(iter->id());
+    } else if (fields_ == dynamic(kTimeKey)) {
+      v = iter->value().ts();
+    } else {
+      v = iter->value().atNoThrow(fields_);
+      if (firstTime_ && !v.empty()) {
+        // Try to learn the type of the attribute
+        firstTime_ = false;
+        for (auto& val : values) {
+          val.castTo(v);
+        }
+      }
+    }
+  } else {
+    auto vec = vector_dynamic_t();
+    for (const auto& field : fields_) {
+      if (dynamic(field.second.get()) == kIdKey) {
+        vec.emplace_back(static_cast<int64_t>(iter->id()));
+      } else if (dynamic(field.second.get()) == kTimeKey) {
+        vec.emplace_back(iter->value().ts());
+      } else {
+        vec.push_back(iter->value().atNoThrow(field.second.get()));
+      }
+    }
+    v = std::move(vec);
+  }
+
+  const dynamic& rhs = values.size() > 1 ? values_ : values[0];
+  switch (filterType_) {
+  case FilterType::GE:
+    return v >= rhs;
+  case FilterType::GT:
+    return v > rhs;
+  case FilterType::LE:
+    return v <= rhs;
+  case FilterType::LT:
+    return v < rhs;
+  case FilterType::RANGE:
+    return v >= values.at(0) && v <= values.at(1);
+  case FilterType::EQ:
+    return std::find(values.begin(), values.end(), v) != values.end();
+  case FilterType::NE:
+    return (v != rhs);
+  case FilterType::PREFIX:
+    try {
+      folly::StringPiece sp = v.is_of<folly::StringPiece>()
+                                  ? v.get<folly::StringPiece>()
+                                  : v.getRef<std::string>();
+      return sp.startsWith(rhs.get<std::string>());
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to compare by prefix: " << e.what();
+      return false;
+    }
+  case FilterType::CONTAINS:
+    try {
+      folly::StringPiece sp = v.is_of<folly::StringPiece>()
+                                  ? v.get<folly::StringPiece>()
+                                  : v.getRef<std::string>();
+      return sp.contains(rhs.get<std::string>());
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "StringPiece contains exception: " << e.what();
+      return false;
+    }
+  case FilterType::INSET:
+    return std::find(values.begin(), values.end(), v) != values.end();
+  default:
+    return false;
+  }
+}
+}

--- a/tests/FilterIteratorTest.cpp
+++ b/tests/FilterIteratorTest.cpp
@@ -1,0 +1,195 @@
+#include <gtest/gtest.h>
+
+#include "ExpectIterator.h"
+
+#include "iterlib/FilterIterator.h"
+#include "iterlib/FutureIterator.h"
+
+using std::unique_ptr;
+using namespace iterlib;
+using namespace iterlib::variant;
+
+TEST(FilterIteratorTest, FilterOneAttr) {
+  const auto res = std::vector<ItemOptimized>{
+      {1, 0, unordered_map_t{{"int1", 1L}, {"int2", 2L}}},
+      {2, 0, unordered_map_t{{"int1", 1L}, {"int2", 3L}}},
+      {3, 0, unordered_map_t{{"int1", 2L}, {"int2", 3L}}},
+  };
+  const auto filteredResult = std::vector<ItemOptimized>{res[0], res[1]};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto filterIt = folly::make_unique<FilterIterator>(it.release());
+  filterIt->setFilter({"int1"}, {"1"}, FilterType::EQ);
+
+  ExpectIterator(filterIt.get(), filteredResult);
+}
+
+TEST(FilterIteratorTest, FilterSecondAttr) {
+  const auto res = std::vector<ItemOptimized>{
+      {1, 0, unordered_map_t{{"int1", 1L},
+                             {"int2", 1L},
+                             {"string", std::string{"foo"}}}},
+      {2, 0, unordered_map_t{{"int1", 1L},
+                             {"int2", 1L},
+                             {"string", std::string{"bar"}}}},
+      {2, 0, unordered_map_t{{"int1", 1L},
+                             {"int2", 2L},
+                             {"string", std::string{"foo"}}}},
+      {2, 0, unordered_map_t{{"int1", 2L},
+                             {"int2", 2L},
+                             {"string", std::string{"baz"}}}},
+  };
+  const auto filteredResult = std::vector<ItemOptimized>{res[2], res[3]};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto filterIt = folly::make_unique<FilterIterator>(it.release());
+  filterIt->setFilter({"int2"}, {"2"}, FilterType::EQ);
+
+  ExpectIterator(filterIt.get(), filteredResult);
+}
+
+// Demonstrates how tuple comparison is not the same as
+// AND of two filters. See RowwiseFilter test below.
+TEST(FilterIteratorTest, FilterTwoAttrs) {
+  const auto res = std::vector<ItemOptimized>{
+      {1, 0, unordered_map_t{{"int1", 15L}, {"int2", 6L}}},
+      {2, 0, unordered_map_t{{"int1", 10L}, {"int2", 3L}}},
+      {2, 0, unordered_map_t{{"int1", 10L}, {"int2", 5L}}},
+      {2, 0, unordered_map_t{{"int1", 5L}, {"int2", 4L}}},
+  };
+  const auto filteredResult = std::vector<ItemOptimized>{res[0]};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto filterIt = folly::make_unique<FilterIterator>(it.release());
+  filterIt->setFilter({"int1"}, {"10"}, FilterType::GT);
+  auto filterIt2 = folly::make_unique<FilterIterator>(filterIt.release());
+  filterIt2->setFilter({"int2"}, {"3"}, FilterType::GT);
+
+  ExpectIterator(filterIt2.get(), filteredResult);
+}
+
+TEST(FilterIteratorTest, RowwiseFilter) {
+  const auto res = std::vector<ItemOptimized>{
+      {1, 0, unordered_map_t{{"int1", 15L}, {"int2", 6L}}},
+      {2, 0, unordered_map_t{{"int1", 10L}, {"int2", 3L}}},
+      {2, 0, unordered_map_t{{"int1", 10L}, {"int2", 5L}}},
+      {2, 0, unordered_map_t{{"int1", 5L}, {"int2", 4L}}},
+  };
+  const auto filteredResult = std::vector<ItemOptimized>{res[0], res[2]};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto filterIt = folly::make_unique<FilterIterator>(it.release());
+  filterIt->setFilter({"int1", "int2"}, std::vector<dynamic>{{10L, 3L}},
+                      FilterType::GT);
+  ExpectIterator(filterIt.get(), filteredResult);
+}
+
+TEST(FilterIteratorTest, FilterSecondStringAttr) {
+  const auto res = std::vector<ItemOptimized>{
+      {1, 0, unordered_map_t{{"int1", 1L},
+                             {"string1", std::string{"a"}},
+                             {"string2", std::string{"foo"}}}},
+      {2, 0, unordered_map_t{{"int1", 1L},
+                             {"string1", std::string{"a"}},
+                             {"string2", std::string{"bar"}}}},
+      {2, 0, unordered_map_t{{"int1", 1L},
+                             {"string1", std::string{"b"}},
+                             {"string2", std::string{"foo"}}}},
+      {2, 0, unordered_map_t{{"int1", 2L},
+                             {"string1", std::string{"b"}},
+                             {"string2", std::string{"baz"}}}},
+  };
+  const auto filteredResult = std::vector<ItemOptimized>{res[0], res[2]};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto filterIt = folly::make_unique<FilterIterator>(it.release());
+  filterIt->setFilter({"string2"}, {"foo"}, FilterType::EQ);
+
+  ExpectIterator(filterIt.get(), filteredResult);
+}
+
+TEST(FilterByPrefix, EmptyPrefix) {
+  const auto res = std::vector<ItemOptimized>{
+      {1, 0, unordered_map_t{{"field", std::string{"baz"}}}},
+      {2, 0, unordered_map_t{{"field", std::string{"foo"}}}},
+      {3, 0, unordered_map_t{{"field", std::string{"bar"}}}},
+  };
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto filterIt = folly::make_unique<FilterIterator>(it.release());
+  filterIt->setFilter({"field"}, {""}, FilterType::PREFIX);
+  ExpectIterator(filterIt.get(), res);
+}
+
+TEST(FilterByPrefix, NonEmptyPrefix) {
+  const auto res = std::vector<ItemOptimized>{
+      {1, 0, unordered_map_t{{"field", std::string{"bar"}}}},
+      {2, 0, unordered_map_t{{"field", std::string{"foo"}}}},
+      {3, 0, unordered_map_t{{"field", std::string{"foobar"}}}},
+  };
+  const auto expectedRes = std::vector<ItemOptimized>{res[1], res[2]};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto filterIt = folly::make_unique<FilterIterator>(it.release());
+  filterIt->setFilter({"field"}, {"foo"}, FilterType::PREFIX);
+  ExpectIterator(filterIt.get(), expectedRes);
+}
+
+TEST(FilterContains, Simple) {
+  const auto res = std::vector<ItemOptimized>{
+      {1, 0, unordered_map_t{{"field", std::string{"bar"}}}},
+      {2, 0, unordered_map_t{{"field", std::string{"foo"}}}},
+      {3, 0, unordered_map_t{{"field", std::string{"foobar"}}}},
+  };
+  const auto expectedRes = std::vector<ItemOptimized>{res[1], res[2]};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto filterIt = folly::make_unique<FilterIterator>(it.release());
+  filterIt->setFilter({"field"}, {"oo"}, FilterType::CONTAINS);
+  ExpectIterator(filterIt.get(), expectedRes);
+}
+
+TEST(FilterIteratorTest, InsetOneElement) {
+  const auto res = std::vector<ItemOptimized>{
+      {1, 0, unordered_map_t{{"field", std::string{"bar"}}}},
+      {2, 0, unordered_map_t{{"field", std::string{"foo"}}}},
+      {3, 0, unordered_map_t{{"field", std::string{"foobar"}}}},
+  };
+  const auto expectedRes = std::vector<ItemOptimized>{res[1]};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto filterIt = folly::make_unique<FilterIterator>(it.release());
+  filterIt->setFilter({"field"}, {"foo"}, FilterType::INSET);
+  ExpectIterator(filterIt.get(), expectedRes);
+}
+
+TEST(FilterIteratorTest, InsetManyElements) {
+  const auto res = std::vector<ItemOptimized>{
+      {1, 0, unordered_map_t{{"field", std::string{"bar"}}}},
+      {2, 0, unordered_map_t{{"field", std::string{"foo"}}}},
+      {3, 0, unordered_map_t{{"field", std::string{"foobar"}}}},
+      {4, 0, unordered_map_t{{"field", std::string{"bar"}}}},
+      {5, 0, unordered_map_t{{"field", std::string{"ruby"}}}},
+  };
+  const auto expectedRes = std::vector<ItemOptimized>{res[0], res[3], res[4]};
+
+  auto it =
+      folly::make_unique<FutureIterator<ItemOptimized>>(folly::makeFuture(res));
+  auto filterIt = folly::make_unique<FilterIterator>(it.release());
+  filterIt->setFilter({"field"}, {"bar", "ruby"}, FilterType::INSET);
+  ExpectIterator(filterIt.get(), expectedRes);
+}
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/IteratorTest.cpp
+++ b/tests/IteratorTest.cpp
@@ -14,11 +14,6 @@
 #include "iterlib/OrIterator.h"
 #include "iterlib/DifferenceIterator.h"
 
-#include "iterlib/LetIterator.h"
-#include "iterlib/MergeIterator.h"
-#include "iterlib/NestIterator.h"
-#include "iterlib/ProjectIterator.h"
-
 using namespace folly;
 using namespace iterlib::variant;
 using namespace iterlib;


### PR DESCRIPTION

This adds an order preserving filter functionality to iterlib.
Subclasses can override the `match()` method to customize how filtering is done.