### PR TITLE
[python] Support obj queries

### DIFF
--- a/python/execute.py
+++ b/python/execute.py
@@ -14,7 +14,7 @@ import visitor
 
 from contextlib import ExitStack
 from functools import partial
-from item import Item
+from item import Item, IDKEY
 from typing import Callable, Iterable, List
 from walk import dict_to_item, leaf_it, materialize_walk, path_it, walk
 
@@ -63,12 +63,12 @@ def count_it(iter: Iterable) -> int:
 
 def intersect(its: List[Iterable]) -> Iterable:
     source = heapq.merge(*its, reverse=True)
-    return iter([k for k, g in itertools.groupby(source, project_item([":id"])) if count_it(g) == len(its)])
+    return iter([k for k, g in itertools.groupby(source, project_item([IDKEY])) if count_it(g) == len(its)])
 
 
 def union(its: List[Iterable]) -> Iterable:
     source = heapq.merge(*its, reverse=True)
-    return iter([k for k, g in itertools.groupby(source, project_item([":id"]))])
+    return iter([k for k, g in itertools.groupby(source, project_item([IDKEY]))])
 
 
 def reduce(function, iterable, initializer=None):
@@ -105,7 +105,7 @@ def merge(its):
 
 def dictify(id_list: Iterable[int]) -> Iterable[Item]:
     for x in id_list:
-        yield Item({":id": x})
+        yield Item({IDKEY: x})
 
 
 def ldictify(id_list):
@@ -114,7 +114,7 @@ def ldictify(id_list):
 
 def undictify(dict_it: Iterable[Item]) -> Iterable[int]:
     for i in dict_it:
-        yield i[":id"]
+        yield i[IDKEY]
 
 
 def apply_func(x, mapFunc):
@@ -128,7 +128,7 @@ class AbstractSyntaxTreeVisitor(visitor.Visitor):
         self.parent_iter = None
         self.parent_key = None
         if id1s:
-            self.root = {id1[":id"]: {} for id1 in id1s}
+            self.root = {id1[IDKEY]: {} for id1 in id1s}
         else:
             self.root = Item({None:  self.iter})
         self.id1s = id1s
@@ -316,7 +316,7 @@ class AbstractSyntaxTreeVisitor(visitor.Visitor):
     def _visit_driver_obj(it, key, driver):
         with ExitStack() as stack:
             for i in it:
-                id_i = i[":id"]
+                id_i = i[IDKEY]
                 res = driver(key, id_i)
                 for k, v in res.items():
                     stack.callback(i.__setitem__, k, v)
@@ -331,7 +331,7 @@ class AbstractSyntaxTreeVisitor(visitor.Visitor):
     def _visit_driver_assoc(it, key, driver):
         with ExitStack() as stack:
             for root, parent, k, i in it:
-                id_i = i[":id"]
+                id_i = i[IDKEY]
                 res = driver(key, id_i)
                 stack.callback(i.__setitem__, str(key), res)
         return it

--- a/python/item.py
+++ b/python/item.py
@@ -10,6 +10,7 @@ def pprint_json(d):
     s = json.dumps(d, indent=4, sort_keys=True)
     print(s)
 
+IDKEY = ":id"
 
 class Item(OrderedDict):
     """Like an OrderedDict, but treats :id as special for
@@ -17,11 +18,11 @@ class Item(OrderedDict):
     """
 
     def __lt__(self, other):
-        return self[":id"] < other[":id"]
+        return self[IDKEY] < other[IDKEY]
 
     def __eq__(self, other):
-        if (":id" in self):
-            return self[":id"] == other[":id"]
+        if (IDKEY in self):
+            return self[IDKEY] == other[IDKEY]
         else:
             return dict.__eq__(self, other)
 
@@ -29,7 +30,7 @@ class Item(OrderedDict):
         return dict.__repr__(self)
 
     def __hash__(self):
-        if (":id" in self):
-            return hash(self[":id"])
+        if (IDKEY in self):
+            return hash(self[IDKEY])
         else:
             return 0

--- a/python/kvstore.py
+++ b/python/kvstore.py
@@ -8,7 +8,7 @@ import json
 import leveldb
 import validate
 
-from item import pprint_json
+from item import pprint_json, IDKEY
 
 
 class KVExecutor(execute.AbstractSyntaxTreeVisitor):
@@ -48,7 +48,7 @@ class KVExecutor(execute.AbstractSyntaxTreeVisitor):
             # TODO: handle this in RangeIter using a prefix scan
             if id1 != id or atype != assoc:
                 break
-            l.append({':id': id2, ':time': atime, 'data': v})
+            l.append({IDKEY: id2, ':time': atime, 'data': v})
         return l
 
 

--- a/python/mock.py
+++ b/python/mock.py
@@ -7,7 +7,7 @@ import execute
 import random
 import validate
 
-from item import pprint_json
+from item import pprint_json, IDKEY
 
 
 class MockExecutor(execute.AbstractSyntaxTreeVisitor):
@@ -17,13 +17,13 @@ class MockExecutor(execute.AbstractSyntaxTreeVisitor):
     """
 
     def driver_obj(self, key, id):
-        return {':id': id, 'name': 'id%d' % id,
+        return {IDKEY: id, 'name': 'id%d' % id,
                  'age': random.choice([16, 17, 18])}
 
     def driver_assoc(self, assoc, id):
         l = []
         for x in range(id * 10, id * 10 + 3):
-            l.append({':id': x, 'name': 'id%d' % x,
+            l.append({IDKEY: x, 'name': 'id%d' % x,
                       'age': random.choice([16, 17, 18])})
         return l
 

--- a/python/mock.py
+++ b/python/mock.py
@@ -16,8 +16,9 @@ class MockExecutor(execute.AbstractSyntaxTreeVisitor):
        a database to implement similar functionality.
     """
 
-    def driver_obj(self, id_list):
-        return [int(x) + 1 for x in id_list]
+    def driver_obj(self, key, id):
+        return {':id': id, 'name': 'id%d' % id,
+                 'age': random.choice([16, 17, 18])}
 
     def driver_assoc(self, assoc, id):
         l = []

--- a/python/mock.py
+++ b/python/mock.py
@@ -51,6 +51,7 @@ if __name__ == '__main__':
     parser.add_argument("-t", "--tree", help="hierarchical tree output",
                         action="store_true")
     args, query = parser.parse_known_args()
+    random.seed(100)  # so tests are deterministic
     if args.tree:
         tree = test_execute_hier(query[0])
         pprint_json(execute.materialize_walk(tree))

--- a/python/nested_tests.py
+++ b/python/nested_tests.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3.6
+# Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+
+import ast
+import unittest
+import random
+
+from mock import test_execute
+from walk import materialize_walk
+
+class Queries(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        self.maxDiff = None
+        random.seed(100)  # so tests are deterministic
+        super(Queries, self).__init__(*args, **kwargs)
+
+    def assertMapEqual(self, m1, m2):
+        m1 = materialize_walk(m1)
+        m2 = ''.join([line.lstrip() for line in m2.splitlines()])
+        m2 = ast.literal_eval(m2)
+        self.assertEqual(str(m1), str(m2))
+
+    def test_obj_query(self):
+        expected = """
+        [
+            {
+                "None": [
+                    {
+                        ":id": 3,
+                        "age": 16,
+                        "name": "id3"
+                    },
+                    {
+                        ":id": 2,
+                        "age": 17,
+                        "name": "id2"
+                    },
+                    {
+                        ":id": 1,
+                        "age": 17,
+                        "name": "id1"
+                    }
+                ]
+            }
+        ]
+        """
+        self.assertMapEqual(test_execute("(->> (3 2 1) (obj))"), expected)
+
+    def test_obj_query_with_ops(self):
+        expected = """
+        [
+            {
+                "None": [
+                    {
+                        ":id": 3,
+                        "age": 16,
+                        "name": "id3"
+                    },
+                    {
+                        ":id": 2,
+                        "age": 18,
+                        "name": "id2"
+                    }
+                ]
+            }
+        ]
+        """
+        self.assertMapEqual(test_execute("(->> (3 2 1) (obj) (limit 2))"), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/walk.py
+++ b/python/walk.py
@@ -59,8 +59,8 @@ def walk(d):
 def leaf_it(d):
     """Similar to walk above, but doesn't provide reference to
        parent"""
-    for parent, key, y in _walk({}, None, d):
-        yield y
+    for parent, key, leaf in _walk({}, None, d):
+        yield leaf
 
 
 def _path_walk(path, d):

--- a/python/walk.py
+++ b/python/walk.py
@@ -7,7 +7,7 @@
 """
 
 import collections
-from item import Item
+from item import Item, IDKEY
 
 
 def is_leaf(d):
@@ -15,7 +15,7 @@ def is_leaf(d):
     for k, v in d.items():
         if isinstance(v, list):
             for i in v:
-                if ":id" in i:
+                if IDKEY in i:
                     has_child = True
                     break
     return not has_child
@@ -65,7 +65,7 @@ def leaf_it(d):
 
 def _path_walk(path, d):
     if isinstance(d, dict):
-        if ":id" in d:
+        if IDKEY in d:
             yield (path, d)
         else:
             for k, v in d.items():


### PR DESCRIPTION
```
./mock.py "(->> (3 2 1) (obj))"
[   
    {   
        ":id": 3,
        "age": 16,
        "name": "id3"
    },           
    {            
        ":id": 2,
        "age": 18,
        "name": "id2"
    },   
    {   
        ":id": 1,
        "age": 18,
        "name": "id1"
    }
]
```

Was returning just a list of ids before.

Also refactor visit_assoc a bit.